### PR TITLE
chore: remove air defaults

### DIFF
--- a/package/air.toml
+++ b/package/air.toml
@@ -1,10 +1,3 @@
 [format]
 line-width = 180                    # same as .editorconfig
-indent-width = 2                    # same as .editorconfig
-indent-style = "space"              # same as .editorconfig
 line-ending = "lf"                  # same as .editorconfig
-persistent-line-breaks = true       # preserve existing line breaks when reformatting
-default-exclude = true              # use built-in default exclusions
-
-
-# you can use "exclude" and "skip" to avoid formatting certain globs


### PR DESCRIPTION
 Most the settings here were already the air defaults, I don't think there is gain in setting them.
 See here: https://posit-dev.github.io/air/configuration.html#example-configuration