### PR TITLE
use correct clang-format option

### DIFF
--- a/package/.clang-format
+++ b/package/.clang-format
@@ -19,4 +19,4 @@ AlignAfterOpenBracket: DontAlign  # don't align under the opening bracket
 Cpp11BracedListStyle: true
 
 # One-line statements
-AllowShortIfStatementsOnASingleLine: true  # allow 'if (x) return;' on one line
+AllowShortIfStatementsOnASingleLine: WithoutElse  # allow 'if (x) return;' on one line


### PR DESCRIPTION
there is no boolean for AllowShortIfStatementsOnASingleLine