### PR TITLE
fix(quarto-netlify-preview): use $GITHUB_WORKSPACE for --dir

### DIFF
--- a/quarto-netlify-preview/action.yml
+++ b/quarto-netlify-preview/action.yml
@@ -1,0 +1,47 @@
+name: quarto-netlify-preview
+description: 'Deploy quarto preview to netlify'
+inputs:
+  netlify_auth_token:
+    description: 'Netlify auth token'
+    required: true
+  netlify_site_id:
+    description: 'Netlify site id'
+    required: true
+  github_token:
+    description: 'Github token'
+  path:
+    description: 'Path to rendered site'
+    required: true
+    default: '.'
+  netlify_url:
+    description: 'Netlify site url'
+    required: true
+    default: '.'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install netlify cli
+      run: npm install netlify-cli -g
+      shell: bash
+
+    - name: Get pull request id
+      run: echo "pr_id=$(echo "${{ github.ref_name }}" | tr / -)" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Deploy to netlify
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ inputs.netlify_auth_token }}
+        NETLIFY_SITE_ID: ${{ inputs.netlify_site_id }}
+      run: netlify deploy --alias ${{ env.pr_id }} --dir "$GITHUB_WORKSPACE/${{ inputs.path }}"
+      shell: bash
+
+    - name: Add url comment
+      if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        token: ${{ inputs.GITHUB_TOKEN }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          [Preview](https://${{ env.pr_id }}--${{ inputs.netlify_url }})
+


### PR DESCRIPTION
## Summary

The `quarto-netlify-preview` composite action (consumed via `mlr-org/actions/quarto-netlify-preview@v1`) fails when the calling job runs inside a `container:`.

Concretely, https://github.com/mlr-org/mlr3website/actions/runs/26513983520/job/78130797496 fails with:

```
Error: The deploy directory "/home/runner/work/mlr3website/mlr3website/mlr-org/_site" has not been found.
```

while the netlify-cli's own resolved config in the same log reports the workspace as `/__w/mlr3website/mlr3website` — i.e. the directory exists, just under a different path.

## Cause

The deploy step uses:

```yaml
run: netlify deploy --alias ${{ env.pr_id }} --dir ${{ github.workspace }}/${{ inputs.path }}
```

For a `container:` job, the `${{ github.workspace }}` expression evaluates to the **host** path (`/home/runner/work/...`) at workflow-parse time, but the repo is mounted inside the container at `/__w/...`. The env var `$GITHUB_WORKSPACE` is set by the runner inside the container to the in-container mount path, and is the correct thing to use here.

## Change

```diff
-      run: netlify deploy --alias ${{ env.pr_id }} --dir ${{ github.workspace }}/${{ inputs.path }}
+      run: netlify deploy --alias ${{ env.pr_id }} --dir "$GITHUB_WORKSPACE/${{ inputs.path }}"
```

## Caveat about this PR

The `quarto-netlify-preview/action.yml` file lives only on the `v1` tag, not on `main`, so this PR's diff shows the entire file as added. The real change is the one-line `--dir` swap shown above. After merge, the `v1` tag would need to be moved (or a new `v1.x.x` cut) for downstream consumers like `mlr3website` to pick it up.

## Test plan

- [ ] After merge + retag, re-run https://github.com/mlr-org/mlr3website/actions/workflows/build-website.yml on PR #217 and confirm the `Deploy netlify preview` step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)